### PR TITLE
feat(hooks): add project extension points for hook customization

### DIFF
--- a/hooks/_lib/common.sh
+++ b/hooks/_lib/common.sh
@@ -40,6 +40,15 @@ is_test_file() {
   echo "$1" | grep -qiE '(test|spec|__test__)'
 }
 
+# Run project-specific extension for the calling hook.
+# Usage: call at end of any hook script.
+# Looks for hooks/project/<caller-basename>-ext.sh
+run_project_extensions() {
+  local caller="${1:-$(basename "${BASH_SOURCE[1]}" .sh)}"
+  local ext="hooks/project/${caller}-ext.sh"
+  [ -f "$ext" ] && source "$ext"
+}
+
 find_active_plan() {
   # Priority 1: explicit .active pointer
   if [ -f "docs/plans/.active" ]; then

--- a/hooks/feedback/context-enrichment.sh
+++ b/hooks/feedback/context-enrichment.sh
@@ -202,4 +202,6 @@ if [ -n "$OUTPUT" ]; then
   fi
 fi
 
+run_project_extensions
+
 exit 0

--- a/hooks/gate/pre-write.sh
+++ b/hooks/gate/pre-write.sh
@@ -221,5 +221,6 @@ gate_plan_structure
 gate_checklist
 scan_content
 inject_plan_context || true
+run_project_extensions
 
 exit 0


### PR DESCRIPTION
## What
- Add `run_project_extensions()` to `common.sh`
- Each hook can be extended via `hooks/project/<hook-name>-ext.sh`
- Applied to `gate/pre-write.sh` and `feedback/context-enrichment.sh`

## Why
Projects using omcc as submodule had to copy hooks and maintain them independently. When omcc updated hooks, projects fell out of sync. Now projects can symlink omcc hooks and keep custom logic in `hooks/project/` extension files.