### PR TITLE
fix(init-project): Make init-project.sh resilient and idempotent

### DIFF
--- a/tools/init-project.sh
+++ b/tools/init-project.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Initialize a new project with oh-my-kiro framework
 # Usage: ./init-project.sh /path/to/project [project-name] [--type coding|gtm] [--knowledge file|openviking]
+#
+# Resilient version: skips files that already exist, guards every copy,
+# and doesn't hard-fail on optional template files.
 
 set -e
 
@@ -55,99 +58,161 @@ case "$PROJECT_TYPE" in
     ;;
 esac
 
-if [ -f "$TARGET/CLAUDE.md" ] || [ -f "$TARGET/AGENTS.md" ]; then
-  echo "⚠️  $TARGET already has CLAUDE.md or AGENTS.md. Aborting to prevent overwrite."
-  exit 1
-fi
+# ── Helper: copy file only if source exists and target doesn't ────────────────
+safe_cp() {
+  local src="$1" dst="$2"
+  if [ ! -e "$src" ]; then
+    echo "  ⏭  Skipping (source missing): $src"
+    return 0
+  fi
+  if [ -e "$dst" ]; then
+    echo "  ⏭  Skipping (already exists): $dst"
+    return 0
+  fi
+  cp "$src" "$dst"
+}
+
+# ── Helper: copy directory only if source exists and target doesn't ───────────
+safe_cp_r() {
+  local src="$1" dst="$2"
+  if [ ! -d "$src" ]; then
+    echo "  ⏭  Skipping dir (source missing): $src"
+    return 0
+  fi
+  if [ -d "$dst" ]; then
+    echo "  ⏭  Skipping dir (already exists): $dst"
+    return 0
+  fi
+  # -RP: don't follow symlinks (avoids cycles from self-referencing links)
+  cp -RP "$src" "$dst"
+}
+
+# ── Helper: create symlink only if it doesn't already exist ───────────────────
+safe_ln() {
+  local target="$1" link="$2"
+  if [ -L "$link" ] || [ -e "$link" ]; then
+    echo "  ⏭  Skipping link (already exists): $link"
+    return 0
+  fi
+  ln -sf "$target" "$link"
+}
+
+# ── Helper: sed in-place (macOS + Linux compatible) ───────────────────────────
+portable_sed_i() {
+  local pattern="$1" file="$2"
+  sed -i '' "$pattern" "$file" 2>/dev/null || sed -i "$pattern" "$file"
+}
 
 echo "🚀 Initializing: $TARGET ($PROJECT_NAME) [type=$PROJECT_TYPE]"
 
+# ── Create directory structure ────────────────────────────────────────────────
 mkdir -p "$TARGET"/{.kiro/rules,.kiro/agents,knowledge/product,docs/{designs,plans,research,decisions},tools,templates}
 
-# ── Copy CLAUDE.md ────────────────────────────────────────────────────────────
-cp "$TEMPLATE_DIR/CLAUDE.md" "$TARGET/CLAUDE.md"
-sed -i '' "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/CLAUDE.md" 2>/dev/null || \
-sed -i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/CLAUDE.md"
+# ── Copy CLAUDE.md (optional — only if template has one) ─────────────────────
+if [ -f "$TEMPLATE_DIR/CLAUDE.md" ]; then
+  if safe_cp "$TEMPLATE_DIR/CLAUDE.md" "$TARGET/CLAUDE.md"; then
+    [ -f "$TARGET/CLAUDE.md" ] && portable_sed_i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/CLAUDE.md"
+  fi
+else
+  echo "  ℹ  No CLAUDE.md in template — skipping"
+fi
 
 # ── Assemble AGENTS.md ────────────────────────────────────────────────────────
-SECTIONS_DIR="$TEMPLATE_DIR/templates/agents-sections"
-TYPES_DIR="$TEMPLATE_DIR/templates/agents-types"
-TYPE_TEMPLATE="$TYPES_DIR/$PROJECT_TYPE.md"
-
-if [ -d "$SECTIONS_DIR" ] && [ -f "$TYPE_TEMPLATE" ]; then
-  # Assemble: type template + each section listed in OMK SECTIONS comment
-  # Parse "<!-- OMK SECTIONS: a b c -->" from type template
-  SECTIONS_LINE=$(grep "OMK SECTIONS:" "$TYPE_TEMPLATE" | head -1)
-  SECTION_NAMES=$(echo "$SECTIONS_LINE" | sed 's/.*OMK SECTIONS: *//;s/ *-->.*//')
-
-  # Start with type template content (strip the OMK SECTIONS marker line)
-  grep -v "OMK SECTIONS:" "$TYPE_TEMPLATE" > "$TARGET/AGENTS.md"
-
-  # Append each section
-  for section in $SECTION_NAMES; do
-    section_file="$SECTIONS_DIR/$section.md"
-    if [ -f "$section_file" ]; then
-      echo "" >> "$TARGET/AGENTS.md"
-      cat "$section_file" >> "$TARGET/AGENTS.md"
-    fi
-  done
-
-  # Substitute project name
-  sed -i '' "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md" 2>/dev/null || \
-  sed -i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md"
-
+if [ -f "$TARGET/AGENTS.md" ]; then
+  echo "  ⏭  Skipping AGENTS.md (already exists)"
 else
-  # Fallback: templates/ not found — copy plain AGENTS.md as before
-  cp "$TEMPLATE_DIR/AGENTS.md" "$TARGET/AGENTS.md"
-  sed -i '' "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md" 2>/dev/null || \
-  sed -i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md"
+  SECTIONS_DIR="$TEMPLATE_DIR/templates/agents-sections"
+  TYPES_DIR="$TEMPLATE_DIR/templates/agents-types"
+  TYPE_TEMPLATE="$TYPES_DIR/$PROJECT_TYPE.md"
+
+  if [ -d "$SECTIONS_DIR" ] && [ -f "$TYPE_TEMPLATE" ]; then
+    SECTIONS_LINE=$(grep "OMK SECTIONS:" "$TYPE_TEMPLATE" | head -1)
+    SECTION_NAMES=$(echo "$SECTIONS_LINE" | sed 's/.*OMK SECTIONS: *//;s/ *-->.*//')
+    grep -v "OMK SECTIONS:" "$TYPE_TEMPLATE" > "$TARGET/AGENTS.md"
+    for section in $SECTION_NAMES; do
+      section_file="$SECTIONS_DIR/$section.md"
+      if [ -f "$section_file" ]; then
+        echo "" >> "$TARGET/AGENTS.md"
+        cat "$section_file" >> "$TARGET/AGENTS.md"
+      fi
+    done
+    portable_sed_i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md"
+  elif [ -f "$TEMPLATE_DIR/AGENTS.md" ]; then
+    cp "$TEMPLATE_DIR/AGENTS.md" "$TARGET/AGENTS.md"
+    portable_sed_i "s/\[Project Name\]/$PROJECT_NAME/g" "$TARGET/AGENTS.md"
+  else
+    echo "  ⚠️  No AGENTS.md template found — skipping"
+  fi
 fi
 
 # ── Copy framework files ──────────────────────────────────────────────────────
-cp "$TEMPLATE_DIR/.kiro/settings.json" "$TARGET/.kiro/"
-cp "$TEMPLATE_DIR/.kiro/rules/"*.md "$TARGET/.kiro/rules/"
-# Copy hooks (preserving subdirectory structure)
-cp -r "$TEMPLATE_DIR/hooks" "$TARGET/hooks"
-ln -sf ../hooks "$TARGET/.kiro/hooks"
-ln -sf ../hooks "$TARGET/.kiro/hooks"
-cp "$TEMPLATE_DIR/.kiro/agents/"*.json "$TARGET/.kiro/agents/"
-cp "$TEMPLATE_DIR/knowledge/INDEX.md" "$TARGET/knowledge/" 2>/dev/null || true
-# Create episodes.md and rules.md from clean templates (not OMK's own data)
+
+# .kiro/settings — handle both settings.json (legacy) and settings/ dir
+if [ -f "$TEMPLATE_DIR/.kiro/settings.json" ]; then
+  safe_cp "$TEMPLATE_DIR/.kiro/settings.json" "$TARGET/.kiro/settings.json"
+elif [ -d "$TEMPLATE_DIR/.kiro/settings" ]; then
+  mkdir -p "$TARGET/.kiro/settings"
+  for f in "$TEMPLATE_DIR/.kiro/settings/"*; do
+    [ -f "$f" ] && safe_cp "$f" "$TARGET/.kiro/settings/$(basename "$f")"
+  done
+else
+  echo "  ℹ  No .kiro/settings found in template — skipping"
+fi
+
+# .kiro/rules/
+if [ -d "$TEMPLATE_DIR/.kiro/rules" ]; then
+  for f in "$TEMPLATE_DIR/.kiro/rules/"*.md; do
+    [ -f "$f" ] && safe_cp "$f" "$TARGET/.kiro/rules/$(basename "$f")"
+  done
+fi
+
+# Hooks
+safe_cp_r "$TEMPLATE_DIR/hooks" "$TARGET/hooks"
+safe_ln ../hooks "$TARGET/.kiro/hooks"
+
+# .kiro/agents/
+if [ -d "$TEMPLATE_DIR/.kiro/agents" ]; then
+  for f in "$TEMPLATE_DIR/.kiro/agents/"*.json; do
+    [ -f "$f" ] && safe_cp "$f" "$TARGET/.kiro/agents/$(basename "$f")"
+  done
+fi
+
+# Knowledge
+safe_cp "$TEMPLATE_DIR/knowledge/INDEX.md" "$TARGET/knowledge/INDEX.md"
 for tmpl in episodes.md rules.md; do
   if [ -f "$TEMPLATE_DIR/templates/knowledge/$tmpl" ]; then
-    cp "$TEMPLATE_DIR/templates/knowledge/$tmpl" "$TARGET/knowledge/$tmpl"
+    safe_cp "$TEMPLATE_DIR/templates/knowledge/$tmpl" "$TARGET/knowledge/$tmpl"
   fi
 done
-cp -r "$TEMPLATE_DIR/knowledge/product" "$TARGET/knowledge/" 2>/dev/null || true
-# Overwrite episodes.md and rules.md with clean templates (no OMK-specific data)
-if [ -d "$TEMPLATE_DIR/templates/knowledge" ]; then
-  cp "$TEMPLATE_DIR/templates/knowledge/episodes.md" "$TARGET/knowledge/episodes.md"
-  cp "$TEMPLATE_DIR/templates/knowledge/rules.md" "$TARGET/knowledge/rules.md"
+if [ -d "$TEMPLATE_DIR/knowledge/product" ]; then
+  cp -rn "$TEMPLATE_DIR/knowledge/product/." "$TARGET/knowledge/product/" 2>/dev/null || true
 fi
-cp "$TEMPLATE_DIR/docs/INDEX.md" "$TARGET/docs/"
+
+# Docs
+safe_cp "$TEMPLATE_DIR/docs/INDEX.md" "$TARGET/docs/INDEX.md"
 for d in designs plans research decisions; do
   touch "$TARGET/docs/$d/.gitkeep"
 done
-cp "$TEMPLATE_DIR/.gitignore" "$TARGET/" 2>/dev/null || true
+
+# .gitignore
+safe_cp "$TEMPLATE_DIR/.gitignore" "$TARGET/.gitignore"
 
 # ── Copy skills (preserving structure, symlinked like hooks) ──────────────────
 if [ -d "$TEMPLATE_DIR/skills" ]; then
-  cp -r "$TEMPLATE_DIR/skills" "$TARGET/skills"
-  ln -sf ../skills "$TARGET/.kiro/skills"
-  ln -sf ../skills "$TARGET/.kiro/skills"
+  safe_cp_r "$TEMPLATE_DIR/skills" "$TARGET/skills"
+  safe_ln ../skills "$TARGET/.kiro/skills"
   SKILL_COUNT=$(ls -d "$TARGET/skills/"*/ 2>/dev/null | wc -l | tr -d ' ')
-  echo "📦 Copied $SKILL_COUNT skills"
+  echo "📦 Skills: $SKILL_COUNT"
 fi
 
 # ── Copy commands & link to .kiro/prompts ─────────────────────────────────────
 if [ -d "$TEMPLATE_DIR/commands" ]; then
-  cp -r "$TEMPLATE_DIR/commands" "$TARGET/commands"
-  ln -s ../commands "$TARGET/.kiro/prompts"
+  safe_cp_r "$TEMPLATE_DIR/commands" "$TARGET/commands"
+  safe_ln ../commands "$TARGET/.kiro/prompts"
   echo "📦 Copied commands → .kiro/prompts"
 fi
 
 # ── Create overlay scaffolding ────────────────────────────────────────────────
-# Empty .omk-overlay.json for project-specific skill/hook extensions
 if [ ! -f "$TARGET/.omk-overlay.json" ]; then
   if [ "$KNOWLEDGE_BACKEND" = "openviking" ]; then
     printf '{\n  "extra_skills": [],\n  "extra_hooks": {},\n  "knowledge_backend": "openviking",\n  "openviking": {\n    "data_dir": "data/openviking"\n  }\n}\n' > "$TARGET/.omk-overlay.json"
@@ -156,24 +221,25 @@ if [ ! -f "$TARGET/.omk-overlay.json" ]; then
   fi
 fi
 
-# hooks/project/ directory for project-specific hooks
 mkdir -p "$TARGET/hooks/project"
 
 # Copy EXTENSION-GUIDE.md if available
 if [ -f "$TEMPLATE_DIR/docs/EXTENSION-GUIDE.md" ]; then
-  cp "$TEMPLATE_DIR/docs/EXTENSION-GUIDE.md" "$TARGET/docs/"
+  safe_cp "$TEMPLATE_DIR/docs/EXTENSION-GUIDE.md" "$TARGET/docs/EXTENSION-GUIDE.md"
 fi
 
-# ── Update agent config with project name ────────────────────────────────────
-jq --arg name "$PROJECT_NAME agent" '.description = $name' "$TARGET/.kiro/agents/pilot.json" > "$TARGET/.kiro/agents/pilot.json.tmp" && \
-mv "$TARGET/.kiro/agents/pilot.json.tmp" "$TARGET/.kiro/agents/pilot.json"
+# ── Update agent config with project name (only if jq available + file exists)
+if command -v jq &>/dev/null && [ -f "$TARGET/.kiro/agents/pilot.json" ]; then
+  jq --arg name "$PROJECT_NAME agent" '.description = $name' "$TARGET/.kiro/agents/pilot.json" > "$TARGET/.kiro/agents/pilot.json.tmp" && \
+  mv "$TARGET/.kiro/agents/pilot.json.tmp" "$TARGET/.kiro/agents/pilot.json"
+fi
 
 echo ""
 echo "✅ Done! Project initialized at: $TARGET"
 echo ""
 echo "📁 Structure:"
-echo "  CLAUDE.md              — High-frequency recall (Claude Code)"
-echo "  AGENTS.md              — High-frequency recall (Kiro CLI) [type=$PROJECT_TYPE]"
+[ -f "$TARGET/CLAUDE.md" ] && echo "  CLAUDE.md              — High-frequency recall (Claude Code)"
+[ -f "$TARGET/AGENTS.md" ] && echo "  AGENTS.md              — High-frequency recall (Kiro CLI) [type=$PROJECT_TYPE]"
 echo "  .kiro/rules/           — Enforcement + Reference layers"
 echo "  .kiro/hooks/           — Automated guardrails"
 if [ -n "${SKILL_COUNT:-}" ]; then
@@ -186,4 +252,4 @@ echo "  knowledge/product/     — Product map (features, constraints)"
 echo "  docs/                  — Designs, plans, research, decisions"
 echo "  tools/                 — Reusable scripts"
 echo ""
-echo "👉 Next: Edit AGENTS.md to customize your agent's identity and roles"
+echo "👉 Next: Edit AGENTS.md to customize your agent identity and roles"


### PR DESCRIPTION
### Summary

`init-project.sh` hard-fails on repos that don't match its assumptions. This makes it resilient and fully idempotent.

### Problem

Running `bash oh-my-kiro/tools/init-project.sh . "my-project"` on a real repo fails because:

1. **Hard abort if AGENTS.md exists** — even if CLAUDE.md doesn't
2. **CLAUDE.md template missing** — `cp` fails since the template dir doesn't have one
3. **`settings.json` vs `settings/` directory** — script assumes `settings.json` but the template uses a `settings/` directory with `lsp.json` + `mcp.json`
4. **Symlink cycles in skills** — `cp -r` follows symlinks and loops on `omk-skill-creation`
5. **No idempotency** — running twice clobbers files or fails on existing symlinks

### Fix

- Add `safe_cp`, `safe_cp_r`, `safe_ln` helpers that skip if source is missing or target already exists
- Handle both `settings.json` (legacy) and `settings/` directory layouts
- Use `cp -RP` (don't follow symlinks) to avoid cycles
- Guard `jq` call with `command -v` check
- Make CLAUDE.md copy conditional on template existence
- Full idempotency: safe to run multiple times on the same target

### Testing

Ran on a real repo with existing `.kiro/`, `AGENTS.md`, and `knowledge/` directories:
- First run: copies what's missing, skips what exists ✅
- Second run: skips everything, no errors ✅
